### PR TITLE
Feat: Added command to schedule the scraper's crawl

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -81,6 +81,7 @@ THIRD_PARTY_APPS = [
     "ckeditor",
     "django_countries",
     "hitcount",
+    "django_apscheduler"
 ]
 
 LOCAL_APPS = [
@@ -343,3 +344,15 @@ SOCIALACCOUNT_QUERY_EMAIL = True
 
 
 HITCOUNT_HITS_PER_IP_LIMIT = 1
+
+# See https://docs.djangoproject.com/en/dev/ref/settings/#datetime-format for format string
+# syntax details.
+APSCHEDULER_DATETIME_FORMAT = "N j, Y, f:s a"
+
+# Maximum run time allowed for jobs that are triggered manually via the Django admin site, which
+# prevents admin site HTTP requests from timing out.
+# 
+# Longer running jobs should probably be handed over to a background task processing library
+# that supports multiple background worker processes instead (e.g. Dramatiq, Celery, Django-RQ,
+# etc. See: https://djangopackages.org/grids/g/workers-queues-tasks/ for popular options).
+APSCHEDULER_RUN_NOW_TIMEOUT = 25  # Seconds

--- a/feline/scraper/management/commands/runscheduledcrawl.py
+++ b/feline/scraper/management/commands/runscheduledcrawl.py
@@ -1,0 +1,123 @@
+import logging
+
+from django.conf import settings
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from django.core.management.base import BaseCommand
+from django_apscheduler.jobstores import DjangoJobStore
+from django_apscheduler.models import DjangoJobExecution
+from django_apscheduler import util
+
+from scraper import settings as scraper_settings
+from scrapy.crawler import CrawlerRunner
+from scrapy.settings import Settings
+from scraper.spiders.jobposts import JobPostSpider
+
+from twisted.internet import reactor
+
+
+class ScraperScheduleHandler:
+    logger = logging.getLogger(__name__)
+
+    def __init__(self, scheduler, settings=None, time_zone=settings.TIME_ZONE):
+        self.scheduler = scheduler(timezone=time_zone)
+        self.scheduler.add_jobstore(DjangoJobStore(), "default")
+
+        self.settings = Settings()
+        self.settings.setmodule(settings)
+        self.crawler = CrawlerRunner(settings=self.settings)
+
+    def add_job(self, callback, trigger, *args):
+        callback_id = str(callback.__name__)
+        
+        self.scheduler.add_job(
+            callback,
+            trigger = trigger, 
+            id = callback_id,
+            max_instances = 1,
+            replace_existing = True,
+            args=[*args]
+        )
+
+        self.logger.info(f"Added job '{callback_id}'.")
+
+    @staticmethod
+    @util.close_old_connections
+    def cleanup_job_entries(max_age=604_800):
+        """
+        This job deletes APScheduler job execution entries older than `max_age` from the database.
+        It helps to prevent the database from filling up with old historical records that are no
+        longer useful.
+        
+        :param max_age: The maximum length of time to retain historical job execution records.
+                        Defaults to 7 days.
+        """
+        DjangoJobExecution.objects.delete_old_job_executions(max_age)
+
+    @staticmethod
+    def task(crawler):
+        """
+        This is the job that will be called by the scheduler when it fired.
+        """
+        d = crawler.crawl(JobPostSpider)
+        d.addBoth(lambda _: reactor.stop())
+        reactor.run()
+
+    def start(self, **kwargs):
+        self.add_job(self.task, CronTrigger(**kwargs), self.crawler)
+        self.add_job(self.cleanup_job_entries, CronTrigger(
+            day_of_week="mon", hour="00", minute="00"))
+    
+        try:
+            self.logger.info("Starting scheduler...")
+            self.scheduler.start()
+
+        except KeyboardInterrupt:
+            self.logger.info("Stopping scheduler...")
+            self.scheduler.shutdown()
+            self.logger.info("Scheduler shut down successfully!")
+
+
+class Command(BaseCommand):
+    help = "Daily extract job posts info from different pages"
+    arguments = {
+        "-d": {
+            "dest": "day",
+            "type": str,
+            "choices": ["sun", "mon", "tue", "wen", "thu", "fri", "sat", "*"],
+            "help": """
+                The exact day of the week. Value format (str): sun, mon, tue, wen, thu, fri, sat.
+                If you write *, the task will run every day.""",
+            "default": "*"
+        },
+        "-H": {
+            "dest": "hour",
+            "type": int,
+            "help": """
+                The exact hour of the day. Value format (int): 0 - 23.
+                If you write *, the task will run every hour.""",
+            "default": "0"
+        },
+        "-m": {
+            "dest": "minute",
+            "type": int,
+            "help": """
+                The exact minute of the hour. Value format (int): 0 - 59.
+                If you write *, the task will run every minute.""",
+            "required": False
+        },
+    }
+
+    def add_arguments(self, parser):
+        for argument_name, kwargs in self.arguments.items():
+            parser.add_argument(argument_name, **kwargs)
+
+    def handle(self, *args, **options):
+        scheduler_handler = ScraperScheduleHandler(BlockingScheduler, scraper_settings)
+        scheduler_handler.start(
+            day_of_week = options.get("day"),
+            hour = options.get("hour"),
+            minute = options.get("minute")
+        )

--- a/feline/scraper/management/commands/runscheduledcrawl.py
+++ b/feline/scraper/management/commands/runscheduledcrawl.py
@@ -57,16 +57,16 @@ class ScraperScheduleHandler:
         DjangoJobExecution.objects.delete_old_job_executions(max_age)
 
     @staticmethod
-    def task(crawler):
+    def scraper_crawl(crawler):
         """
-        This is the job that will be called by the scheduler when it fired.
+        This job active the scraper crawling.
         """
         d = crawler.crawl(JobPostSpider)
         d.addBoth(lambda _: reactor.stop())
         reactor.run()
 
     def start(self, **kwargs):
-        self.add_job(self.task, CronTrigger(**kwargs), self.crawler)
+        self.add_job(self.scraper_crawl, CronTrigger(**kwargs), self.crawler)
         self.add_job(self.cleanup_job_entries, CronTrigger(
             day_of_week="mon", hour="00", minute="00"))
     
@@ -94,15 +94,15 @@ class Command(BaseCommand):
         },
         "-H": {
             "dest": "hour",
-            "type": int,
+            "type": str,
             "help": """
                 The exact hour of the day. Value format (int): 0 - 23.
                 If you write *, the task will run every hour.""",
-            "default": "0"
+            "required": False
         },
         "-m": {
             "dest": "minute",
-            "type": int,
+            "type": str,
             "help": """
                 The exact minute of the hour. Value format (int): 0 - 59.
                 If you write *, the task will run every minute.""",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,6 +13,8 @@ django-model-utils==4.1.1  # https://github.com/jazzband/django-model-utils
 django-allauth==0.45.0  # https://github.com/pennersr/django-allauth
 django-crispy-forms==1.13.0  # https://github.com/django-crispy-forms/django-crispy-forms
 django-redis==5.0.0  # https://github.com/jazzband/django-redis
+django-apscheduler==0.6.2 # https://github.com/jcass77/django-apscheduler
+
 # Django REST Framework
 djangorestframework==3.12.4  # https://github.com/encode/django-rest-framework
 django-cors-headers==3.10.0 # https://github.com/adamchainz/django-cors-headers


### PR DESCRIPTION
# Feat:
- Added `django-apscheduler`.
- Custom django command added `runscheduledcrawl`, can be run with `manage.py`, it's allow your to schedule scraper crawling. Write `-h  (help)`to see the required arguments.

# Requirements:
This PR require this other (#10) to work fine.