### PR TITLE
fix: now JOB_CATEGORIES_CHOICES will not call categories in migrations

### DIFF
--- a/feline/jobposts/forms.py
+++ b/feline/jobposts/forms.py
@@ -1,8 +1,16 @@
+import sys
 from django import forms
+from django.db import connection
 from .models import Category, Company, JobPost
 from ckeditor.widgets import CKEditorWidget
 
-JOB_CATEGORIES_CHOICES = [('--', 'Categoria')] + [(category.name, category.name) for category in Category.objects.all()]
+JOB_CATEGORIES_CHOICES = [('--', 'Categoria')]
+
+if 'jobposts_category' in connection.introspection.table_names():
+    JOB_CATEGORIES_CHOICES += [
+        (category.name, category.name)
+        for category in Category.objects.all()
+    ]
 
 
 class JobPostForm(forms.ModelForm):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,25 +1,25 @@
 pytz==2021.3  # https://github.com/stub42/pytz
-python-slugify==5.0.2  # https://github.com/un33k/python-slugify
-Pillow==8.3.2  # https://github.com/python-pillow/Pillow
+python-slugify==6.1.2  # https://github.com/un33k/python-slugify
+Pillow==9.1.1 # https://github.com/python-pillow/Pillow
 argon2-cffi==21.1.0  # https://github.com/hynek/argon2_cffi
-redis==3.5.3  # https://github.com/andymccurdy/redis-py
+redis==4.3.1  # https://github.com/andymccurdy/redis-py
 hiredis==2.0.0  # https://github.com/redis/hiredis-py
 
 # Django
 # ------------------------------------------------------------------------------
-django==3.1.13  # pyup: < 3.2  # https://www.djangoproject.com/
-django-environ==0.7.0  # https://github.com/joke2k/django-environ
-django-model-utils==4.1.1  # https://github.com/jazzband/django-model-utils
-django-allauth==0.45.0  # https://github.com/pennersr/django-allauth
-django-crispy-forms==1.13.0  # https://github.com/django-crispy-forms/django-crispy-forms
-django-redis==5.0.0  # https://github.com/jazzband/django-redis
+django==4.0.4  # pyup: < 3.2  # https://www.djangoproject.com/
+django-environ==0.8.1  # https://github.com/joke2k/django-environ
+django-model-utils==4.2.0  # https://github.com/jazzband/django-model-utils
+django-allauth==0.50.0  # https://github.com/pennersr/django-allauth
+django-crispy-forms==1.14.0  # https://github.com/django-crispy-forms/django-crispy-forms
+django-redis==5.2.0  # https://github.com/jazzband/django-redis
 # Django REST Framework
-djangorestframework==3.12.4  # https://github.com/encode/django-rest-framework
-django-cors-headers==3.10.0 # https://github.com/adamchainz/django-cors-headers
+djangorestframework==3.13.1  # https://github.com/encode/django-rest-framework
+django-cors-headers==3.12.0 # https://github.com/adamchainz/django-cors-headers
 
-django-countries==7.2.1
-git+git://github.com/jazzband/django-taggit
+django-countries==7.3.2
+django-taggit==3.0.0
 
-django-extensions==3.1.3  # https://github.com/django-extensions/django-extensions
-django-ckeditor==6.1.0
-dj-hitcount==1.1.0
+django-extensions==3.1.5  # https://github.com/django-extensions/django-extensions
+django-ckeditor==6.4.1
+dj-hitcount==1.3.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,35 +1,35 @@
 -r base.txt
 
-Werkzeug==2.0.2 # https://github.com/pallets/werkzeug
+Werkzeug==2.1.2 # https://github.com/pallets/werkzeug
 ipdb==0.13.9  # https://github.com/gotcha/ipdb
-psycopg2-binary==2.9.1  # https://github.com/psycopg/psycopg2
+psycopg2-binary==2.9.3  # https://github.com/psycopg/psycopg2
 
 # Testing
 # ------------------------------------------------------------------------------
-mypy==0.910  # https://github.com/python/mypy
-django-stubs==1.8.0  # https://github.com/typeddjango/django-stubs
-pytest==6.2.5  # https://github.com/pytest-dev/pytest
+mypy==0.950  # https://github.com/python/mypy
+django-stubs==1.11.0  # https://github.com/typeddjango/django-stubs
+pytest==7.1.2  # https://github.com/pytest-dev/pytest
 pytest-sugar==0.9.4  # https://github.com/Frozenball/pytest-sugar
 
 # Documentation
 # ------------------------------------------------------------------------------
-sphinx==4.2.0  # https://github.com/sphinx-doc/sphinx
+sphinx==4.5.0  # https://github.com/sphinx-doc/sphinx
 sphinx-autobuild==2021.3.14 # https://github.com/GaretJax/sphinx-autobuild
 
 # Code quality
 # ------------------------------------------------------------------------------
-flake8==3.9.2  # https://github.com/PyCQA/flake8
-flake8-isort==4.0.0  # https://github.com/gforcada/flake8-isort
-coverage==6.0.2  # https://github.com/nedbat/coveragepy
-black==21.9b0  # https://github.com/psf/black
-pylint-django==2.4.4  # https://github.com/PyCQA/pylint-django
-pre-commit==2.15.0  # https://github.com/pre-commit/pre-commit
+flake8==4.0.1  # https://github.com/PyCQA/flake8
+flake8-isort==4.1.1  # https://github.com/gforcada/flake8-isort
+coverage==6.4  # https://github.com/nedbat/coveragepy
+black==22.3.0  # https://github.com/psf/black
+pylint-django==2.5.3  # https://github.com/PyCQA/pylint-django
+pre-commit==2.19.0  # https://github.com/pre-commit/pre-commit
 
 # Django
 # ------------------------------------------------------------------------------
-factory-boy==3.2.0  # https://github.com/FactoryBoy/factory_boy
+factory-boy==3.2.1  # https://github.com/FactoryBoy/factory_boy
 
-django-debug-toolbar==3.2.2  # https://github.com/jazzband/django-debug-toolbar
-django-coverage-plugin==2.0.1  # https://github.com/nedbat/django_coverage_plugin
-pytest-django==4.4.0  # https://github.com/pytest-dev/pytest-django
+django-debug-toolbar==3.4.0  # https://github.com/jazzband/django-debug-toolbar
+django-coverage-plugin==2.0.3  # https://github.com/nedbat/django_coverage_plugin
+pytest-django==4.5.2  # https://github.com/pytest-dev/pytest-django
 faker==9.3.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -3,9 +3,9 @@
 -r base.txt
 
 gunicorn==20.1.0  # https://github.com/benoitc/gunicorn
-psycopg2==2.9.1  # https://github.com/psycopg/psycopg2
+psycopg2==2.9.3  # https://github.com/psycopg/psycopg2
 Collectfast==2.2.0  # https://github.com/antonagestam/collectfast
-sentry-sdk==1.4.3  # https://github.com/getsentry/sentry-python
+sentry-sdk==1.5.12  # https://github.com/getsentry/sentry-python
 
 # Django
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
- now `JOB_CATEGORIES_CHOICES` will not call categories in migrations.
- Changed django version from `3.1.13` to `3.2` to solve a dependency conflict.